### PR TITLE
Fix bug with project version that wasn't processed with toSemver method

### DIFF
--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
@@ -98,7 +98,7 @@ open class GeneratePackagesJsonTask : DefaultTask() {
 
         val packagesJson: Map<*, *> = mapOf(
                 "name" to (moduleNames.singleOrNull() ?: project.name ?: "noname"),
-                "version" to (project.version.toString().let { if (it == Project.DEFAULT_VERSION) toSemver(null) else it }),
+                "version" to (toSemver(project.version.toString())),
                 "description" to "simple description",
                 "main" to (moduleNames.singleOrNull()),
                 "dependencies" to dependencies.associateBy({ it.name }, { it.versionOrUri }),

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/util/semver.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/util/semver.kt
@@ -1,7 +1,11 @@
 package org.jetbrains.kotlin.gradle.frontend.util
 
+import org.gradle.api.Project.DEFAULT_VERSION
+
 fun toSemver(version: String?) = buildString {
-    if (version == null) {
+    if (version == null ||
+        version == DEFAULT_VERSION) {
+
         return "0.0.0"
     }
 

--- a/kotlin-frontend/src/test/kotlin/org/jetbrains/kotlin/gradle/frontend/SemverTest.kt
+++ b/kotlin-frontend/src/test/kotlin/org/jetbrains/kotlin/gradle/frontend/SemverTest.kt
@@ -1,14 +1,16 @@
 package org.jetbrains.kotlin.gradle.frontend
 
-import org.jetbrains.kotlin.gradle.frontend.util.*
-import org.junit.*
-import kotlin.test.*
+import org.gradle.api.Project.DEFAULT_VERSION
+import org.jetbrains.kotlin.gradle.frontend.util.toSemver
+import org.junit.Test
+import kotlin.test.assertEquals
 
 class SemverTest {
     @Test
     fun testEmpty() {
         assertEquals("0.0.0", toSemver(""))
         assertEquals("0.0.0", toSemver(null))
+        assertEquals("0.0.0", toSemver(DEFAULT_VERSION))
     }
 
     @Test


### PR DESCRIPTION
In my `build.gradle` I had such line: `version '1.0'`.

When `kotlin-frontend-plugin` tries to install dependencies with `npm`, there was no success because `npm` thinks that `version: "1.0"` in `package.json` is invalid. (When using `yarn`, everything is OK)

After changing `version '1.0'` to `version '1.0.0'` in `build.gradle`, everything works fine with `npm` too.

In this PR I added some test for this case and made this action performed automatically while generating `package.json` file.