### PR TITLE
Fix package.json generation on Windows platform

### DIFF
--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
@@ -54,7 +54,7 @@ open class GeneratePackagesJsonTask : DefaultTask() {
     @get:Input
     val moduleNames: List<String> by lazy { project.tasks.withType(KotlinJsCompile::class.java)
             .filter { !it.name.contains("test", ignoreCase = true) }
-            .mapNotNull { it.kotlinOptions.outputFile?.substringAfterLast('/')?.removeSuffix(".js") }
+            .mapNotNull { it.kotlinOptions.outputFile?.replace('\\', '/')?.substringAfterLast('/')?.removeSuffix(".js") }
     }
 
     @OutputFile


### PR DESCRIPTION
On Windows, the name attribute would have the full path, resulting in a silent error in the "npm-install" task and missing dependencies in the frontend.

example:
```
{
   "name": "D:\\Travail\\kotlin-fullstack-sample\\frontend\\build\\js\\frontend",
   ...
}
```

I am not sure how to add tests for this...