### PR TITLE
Fixed bug #17 Specify webpack version and added option for custom karma config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,29 @@ kotlinFrontend {
     }
 }
 ```
+This will generate a config file located at `build/karma.conf.js`.
+
+Note that for your tests to run correctly with webpack their module type must be defined as well:
+```
+compileTestKotlin2Js {
+    kotlinOptions.metaInfo = true
+    kotlinOptions.moduleKind = 'commonjs'
+}
+```
+
+If you would like to use a custom `karma.config.js` then specify it using `customConfigFile`:
+
+```
+kotlinFrontend {
+    karma {
+        customConfigFile = "myKarma.conf.js"
+    }
+}
+```
+
+Your custom config file will be copied to the build folder and renamed to `karma.config.js`.
 
 karma log is located at `build/logs/karma.log`
-
-config file is generated at `build/karma.conf.js`
 
 # Hot module replacement
 

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaExtension.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaExtension.kt
@@ -4,6 +4,9 @@ import org.gradle.api.tasks.*
 
 open class KarmaExtension {
     @Input
+    var customConfigFile: String? = null
+
+    @Input
     var port: Int = 9876
 
     @Input

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaExtension.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaExtension.kt
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.*
 
 open class KarmaExtension {
     @Input
-    var customConfigFile: String? = null
+    var customConfigFile: String = ""
 
     @Input
     var port: Int = 9876

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaStartStopTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaStartStopTask.kt
@@ -39,11 +39,11 @@ open class KarmaStartStopTask : AbstractStartStopTask<Int>() {
         val preprocessors = extension.preprocessors.toMutableList()
         val clientConfig = mutableMapOf<String, Any>()
 
-        extension.customConfigFile?.let {
-          val file = File(project.projectDir.absolutePath + it)
-          file.copyTo(File(project.buildDir.absolutePath+"karma.conf.js"), true)
+        if(extension.customConfigFile.trim() != "") {
+          val file = File(project.projectDir.absolutePath + "\\" + extension.customConfigFile)
+          file.copyTo(File(project.buildDir.absolutePath+"\\karma.conf.js"), true)
 
-        } ?: kotlin.run {
+        } else {
           val config = linkedMapOf(
               "basePath" to project.buildDir.absolutePath,
               "frameworks" to extension.frameworks.toMutableList(),

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaStartStopTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/karma/KarmaStartStopTask.kt
@@ -40,8 +40,8 @@ open class KarmaStartStopTask : AbstractStartStopTask<Int>() {
         val clientConfig = mutableMapOf<String, Any>()
 
         if(extension.customConfigFile.trim() != "") {
-          val file = File(project.projectDir.absolutePath + "\\" + extension.customConfigFile)
-          file.copyTo(File(project.buildDir.absolutePath+"\\karma.conf.js"), true)
+          val file = project.projectDir.resolve(extension.customConfigFile)
+          file.copyTo(project.buildDir.resolve("karma.conf.js"), true)
 
         } else {
           val config = linkedMapOf(

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
@@ -93,14 +93,11 @@ open class GeneratePackagesJsonTask : DefaultTask() {
                     .map { Dependency(it[0], it[2], Dependency.RuntimeScope) }
         }).flatten() + toolsDependencies.filter { it.scope == Dependency.RuntimeScope }
 
-        val devDependencies = mutableListOf<Dependency>()
+        val devDependencies = mutableListOf(*npm.developmentDependencies.toTypedArray())
 
-        devDependencies.addAll(npm.developmentDependencies)
-
-        toolsDependencies.filter{ it.scope == Dependency.DevelopmentScope }.forEach {
-          if(!devDependencies.any { dep ->  dep.name == it.name })
-            devDependencies.add(it)
-        }
+        devDependencies.addAll(toolsDependencies.filter {
+          (it.scope == Dependency.DevelopmentScope) && devDependencies.all { dep ->  dep.name != it.name }
+        })
 
         if (logger.isDebugEnabled) {
             logger.debug(dependencies.joinToString(prefix = "Dependencies:\n", separator = "\n") { "${it.name}: ${it.versionOrUri}" })

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
@@ -93,7 +93,14 @@ open class GeneratePackagesJsonTask : DefaultTask() {
                     .map { Dependency(it[0], it[2], Dependency.RuntimeScope) }
         }).flatten() + toolsDependencies.filter { it.scope == Dependency.RuntimeScope }
 
-        val devDependencies = npm.developmentDependencies + toolsDependencies.filter { it.scope == Dependency.DevelopmentScope }
+        val devDependencies = mutableListOf<Dependency>()
+
+        devDependencies.addAll(npm.developmentDependencies)
+
+        toolsDependencies.filter{ it.scope == Dependency.DevelopmentScope }.forEach {
+          if(!devDependencies.any { dep ->  dep.name == it.name })
+            devDependencies.add(it)
+        }
 
         if (logger.isDebugEnabled) {
             logger.debug(dependencies.joinToString(prefix = "Dependencies:\n", separator = "\n") { "${it.name}: ${it.versionOrUri}" })

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/GeneratePackagesJsonTask.kt
@@ -96,7 +96,7 @@ open class GeneratePackagesJsonTask : DefaultTask() {
         val devDependencies = mutableListOf(*npm.developmentDependencies.toTypedArray())
 
         devDependencies.addAll(toolsDependencies.filter {
-          (it.scope == Dependency.DevelopmentScope) && devDependencies.all { dep ->  dep.name != it.name }
+            (it.scope == Dependency.DevelopmentScope) && devDependencies.all { dep ->  dep.name != it.name }
         })
 
         if (logger.isDebugEnabled) {


### PR DESCRIPTION
This pull request fixes a bug I opened earlier this month where devDependencies that were defined in build.gradle were overridden if they were already included in the front-end-plugin.

For instance devDependency("webpack", "2.6.1") should show up as "webpack": "2.6.1" in package.json but instead was showing up as "webpack": "*" because that's how it was being generated in the front-end-plugin.

Now any devDependencies defined that are also needed by the plugin are no longer overridden like that. If they are not defined then they still show up as "dev-dependency-name": "*".

I also added an option to define a custom karma configuration file if it's needed. I updated the readme explaining that.