### PR TITLE
add TaskInput to GenerateWebPackConfig to consider task dirty when dceTasks are added/removed to/from the project

### DIFF
--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/GenerateWebPackConfigTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/GenerateWebPackConfigTask.kt
@@ -44,6 +44,13 @@ open class GenerateWebPackConfigTask : DefaultTask() {
     @Input
     val exts = project.frontendExtension.defined
 
+    @get:Input
+    private val isDceEnabled: Boolean by lazy {
+        !project.tasks
+                .withType(KotlinJsDce::class.java)
+                .filter { it.isEnabled }.isEmpty()
+    }
+
     init {
         (inputs as TaskInputs).dir(configsDir).optional()
 


### PR DESCRIPTION
fixes https://github.com/Kotlin/kotlin-frontend-plugin/issues/33