### PR TITLE
Use `before` when configuring devserver middleware

### DIFF
--- a/kotlin-frontend/src/main/resources/kotlin/webpack/webpack-dev-server-launcher.js
+++ b/kotlin-frontend/src/main/resources/kotlin/webpack/webpack-dev-server-launcher.js
@@ -44,7 +44,7 @@ var devServer = new WebpackDevServer(
         contentBase: (RunConfig.contentPath ? RunConfig.contentPath : undefined),
         stats: RunConfig.stats || "errors-only",
         hot: true,
-        setup: function(app) {
+        before: function(app) {
             app.get(RunConfig.shutDownPath, function(req, res) {
                 res.json({ shutdown: 'ok' });
                 devServer.close();


### PR DESCRIPTION
Replaces the deprecated `setup` field.