### PR TITLE
Update to 1.2.20. Fix problem with getOutputFile, which returns a file and not a string.

### DIFF
--- a/examples/custom-webpack-config/build.gradle
+++ b/examples/custom-webpack-config/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.1'
+    ext.kotlin_version = '1.2.20'
 
     repositories {
         mavenLocal()
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-frontend:0.0.18-SNAPSHOT"
+        classpath "org.jetbrains.kotlin:kotlin-frontend:0.0.27-SNAPSHOT"
     }
 }
 

--- a/examples/frontend-only/build.gradle
+++ b/examples/frontend-only/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.1.60'
+    ext.kotlin_version = '1.2.20'
 
     repositories {
         jcenter()
@@ -8,7 +8,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-frontend-plugin:0.0.23"
+        classpath "org.jetbrains.kotlin:kotlin-frontend-plugin:0.0.27-SNAPSHOT"
     }
 }
 

--- a/examples/full-stack-example/build.gradle
+++ b/examples/full-stack-example/build.gradle
@@ -2,7 +2,7 @@ group 'org.jetbrains.kotlin.examples'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.1.60'
+    ext.kotlin_version = '1.2.20'
 
     repositories {
         jcenter()
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.jetbrains.kotlin:kotlin-frontend-plugin:0.0.23'
+        classpath 'org.jetbrains.kotlin:kotlin-frontend-plugin:0.0.27-SNAPSHOT'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=0.0.1-SNAPSHOT
 
-kotlin_version=1.1.51
+kotlin_version=1.2.20

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/GenerateWebPackConfigTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/GenerateWebPackConfigTask.kt
@@ -69,7 +69,7 @@ open class GenerateWebPackConfigTask : DefaultTask() {
                     .mapNotNull { it.dependencyProject }
                     .flatMap { it.tasks.filterIsInstance<Kotlin2JsCompile>() }
                     .filter { !it.name.contains("test", ignoreCase = true) }
-                    .map { project.file(it.outputFile) }
+                    .map { it.outputFile }
                     .map { resolveRoots.add(it.parentFile.toRelativeString(project.buildDir)) }
 
             resolveRoots.add(0, File(contextDir).toRelativeString(project.buildDir))


### PR DESCRIPTION
Fixes error when running webpack task on 1.2.20