### PR TITLE
Add mode argument to webpack 

### DIFF
--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackBundleTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackBundleTask.kt
@@ -26,7 +26,8 @@ open class WebPackBundleTask : DefaultTask() {
         ProcessBuilder(
                 nodePath(project, "node").first().absolutePath,
                 project.buildDir.resolve("node_modules/webpack/bin/webpack.js").absolutePath,
-                "--config", webPackConfigFile.absolutePath
+                "--config", webPackConfigFile.absolutePath,
+                "--mode", config.mode
         )
                 .directory(project.buildDir)
                 .startWithRedirectOnFail(project, "node webpack.js")

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackExtension.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackExtension.kt
@@ -27,4 +27,6 @@ open class WebPackExtension(project: Project) : BundleConfig {
     var stats: String = "errors-only"
 
     var webpackConfigFile: Any? = null
+
+    var mode: String = "development"
 }


### PR DESCRIPTION
As they explain in [here](https://medium.com/webpack/webpack-4-mode-and-optimization-5423a6bc597a), with webpack 4 they started soft-requiring this argument.
