### PR TITLE
KFE-92 Allows indexing over npm bundles with intentionally broken package.json files

### DIFF
--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/NpmIndexTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/NpmIndexTask.kt
@@ -63,7 +63,8 @@ open class NpmIndexTask : DefaultTask() {
     }
 
     private fun packageJsonContainsTypes(file: File): Boolean {
-        return (JsonSlurper().parse(file) as Map<*, *>).get("typings") != null
+        val parsedFile = JsonSlurper().parse(file)
+        return (parsedFile is Map<*, *> && parsedFile["typings"] != null)
     }
 
     private fun <T> Iterable<T>.joinToLines(o: Appendable, transform: (T) -> CharSequence) {


### PR DESCRIPTION
Fixes #92 

When processing modules to find those with TypeScript, the current implementation of the `NpmIndexTask` scans all directories in the `$buildDir/node_modules` directory, first looking for first `typings.json` files then for all `package.json` files that may include `typings` blocks.

In attempting to build a new bundler today that would run browserify instead of webpack, I encountered this problem. Browserify pulls in [`module-deps`](https://www.npmjs.com/package/module-deps ) which includes a very thorough test suite, including negative tests. In particular, [this test for an invalid package](https://github.com/browserify/module-deps/blob/master/test/invalid_pkg/package.json) causes the `npm-index` task to fail.

I have put up [this repository](https://github.com/coyotesqrl/demoindexissue) to demonstrate the issue; I am currently attempting to put together a PR but the unit tests are taking longer to run that I had expected. I am about 85% certain that this simple change to `NpmIndexTask` will resolve the problem with no negative repercussions.

An alternative solution would add an exclusion list or exclusion regex to the configuration for the task, but it would require users to empirically determine what to exclude and might prove brittle over time as more dependencies/tests were pulled in.

I see no negative outcome from this straight-forward solution, as an invalid `package.json` file really can not define any TypeScript.