### PR TITLE
Automatically use appropriate webpack mode based on run/build

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ kotlinFrontend {
         port = 8088   // dev server port
         proxyUrl = "" | "http://...."  // URL to be proxied, useful to proxy backend webserver
         stats = "errors-only"  // log level
+        mode = "production" | "development" | "none" // used for webpack 4+ build-in optimizations
     }
 }
 ```
@@ -115,6 +116,8 @@ kotlinFrontend {
 dev server log is located at `build/logs/webpack-dev-server.log`
 
 config file is generated at `build/webpack.config.js`
+
+If mode is not specified, the default behavior is to use development mode for running the dev server, and production mode for creating the final bundle. See [webpack documentation](https://webpack.js.org/concepts/mode/) for more information about modes.
 
 ## webpack configuration customization
 

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/GenerateWebPackConfigTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/GenerateWebPackConfigTask.kt
@@ -130,7 +130,6 @@ open class GenerateWebPackConfigTask : DefaultTask() {
         val resolveRoots = getModuleResolveRoots(false)
 
         val json = linkedMapOf(
-                "mode" to bundle.mode,
                 "context" to getContextDir(false).absolutePath,
                 "entry" to mapOf(
                         bundle.bundleName to kotlinOutput(project).nameWithoutExtension.let { "./$it" }

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/NodeModuleVersion.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/NodeModuleVersion.kt
@@ -1,0 +1,27 @@
+package org.jetbrains.kotlin.gradle.frontend.webpack
+
+import groovy.json.JsonSlurper
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import kotlin.reflect.KProperty
+
+class NodeModuleVersion(project: Project, module: String) {
+    @Suppress("UNCHECKED_CAST")
+    val version: String = project.buildDir.resolve("node_modules/$module/package.json")
+            .let { JsonSlurper().parse(it) as Map<String, Any?> }["version"]
+            ?.let { it as String } ?: throw GradleException("Module \"$module\" not found")
+
+    val major: Int by VersionComponent(0)
+
+    val minor: Int by VersionComponent(1)
+
+    val patch: Int by VersionComponent(2)
+
+    private class VersionComponent(val component: Int) {
+        operator fun getValue(thisRef: NodeModuleVersion, property: KProperty<*>): Int {
+            return thisRef.version.split(".")
+                    .getOrNull(component)
+                    ?.toInt() ?: 0
+        }
+    }
+}

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackBundleTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackBundleTask.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.gradle.frontend.webpack
 
-import groovy.json.JsonSlurper
 import org.gradle.api.*
 import org.gradle.api.tasks.*
 import org.jetbrains.kotlin.gradle.frontend.util.*
@@ -29,23 +28,15 @@ open class WebPackBundleTask : DefaultTask() {
 
     @TaskAction
     fun buildBundle() {
-        @Suppress("UNCHECKED_CAST")
-        val webpackVersion = project.buildDir.resolve("node_modules/webpack/package.json")
-                .let { JsonSlurper().parse(it) as Map<String, Any?> }["version"]
-                ?.let { it as String }
-
         val processBuilderCommands = arrayListOf(
                 nodePath(project, "node").first().absolutePath,
                 project.buildDir.resolve("node_modules/webpack/bin/webpack.js").absolutePath,
                 "--config", webPackConfigFile.absolutePath
         )
-        val webpackMajorVersion = webpackVersion
-                ?.split('.')
-                ?.firstOrNull()
-                ?.toInt()
-        if (webpackMajorVersion != null && webpackMajorVersion >= 4) {
+
+        if (NodeModuleVersion(project, "webpack").major >= 4) {
             processBuilderCommands.addAll(arrayOf(
-                    "--mode", config.mode
+                    "--mode", config.mode ?: "production"
             ))
         }
         ProcessBuilder(processBuilderCommands)

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackExtension.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackExtension.kt
@@ -41,5 +41,6 @@ open class WebPackExtension(project: Project) : BundleConfig {
     var webpackConfigFile: Any? = null
 
     @Input
-    var mode: String = "development"
+    @Optional
+    var mode: String? = null
 }

--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackRunTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/webpack/WebPackRunTask.kt
@@ -77,6 +77,9 @@ open class WebPackRunTask : AbstractStartStopTask<WebPackRunTask.State>() {
                         .replace("require('\$RunConfig\$')",
                                 JsonBuilder(GenerateWebpackHelperTask.config(project, config, webPackConfigFile)).toPrettyString()
                         )
+                        .replace("\$SetMode\$\n",
+                                if (NodeModuleVersion(project, "webpack").major >= 4) "config.mode = \"${config.mode ?: "development"}\";\n" else ""
+                        )
         )
 
         try {

--- a/kotlin-frontend/src/main/resources/kotlin/webpack/webpack-dev-server-launcher.js
+++ b/kotlin-frontend/src/main/resources/kotlin/webpack/webpack-dev-server-launcher.js
@@ -11,6 +11,7 @@ var devServerVersion = require(__dirname + '/node_modules/webpack-dev-server/pac
 var RunConfig = require('$RunConfig$');
 
 var config = require(RunConfig.webPackConfig);
+$SetMode$
 
 for (var name in config.entry) {
     if (config.entry.hasOwnProperty(name)) {

--- a/kotlin-frontend/src/test/kotlin/org/jetbrains/kotlin/gradle/frontend/SimpleFrontendProjectTest.kt
+++ b/kotlin-frontend/src/test/kotlin/org/jetbrains/kotlin/gradle/frontend/SimpleFrontendProjectTest.kt
@@ -97,6 +97,7 @@ class SimpleFrontendProjectTest(gradleVersion: String, kotlinVersion: String) : 
                 block("webpackBundle") {
                     line("port = $port")
                     line("bundleName = \"main\"")
+                    line("mode = \"development\"")
                 }
             }
 


### PR DESCRIPTION
testSimpleProjectWebPackBundleWithDce had to be modified to pass, since the output bundle was now being minified. This was causing the last assertion to fail, since "usedFunction2222" was being changed to something shorter.