### PR TITLE
Ensure npm install spawns correct node executable

### DIFF
--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/NpmInstallTask.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/npm/NpmInstallTask.kt
@@ -50,7 +50,7 @@ open class NpmInstallTask : DefaultTask() {
             ensureSymbolicLink(linkPath, target)
         }
 
-        ProcessBuilder(npmPath, "install")
+        ProcessBuilder(npmPath, "install", "--scripts-prepend-node-path")
                 .directory(project.buildDir)
                 .apply { ensurePath(environment(), npm.parentFile.absolutePath) }
                 .redirectErrorStream(true)


### PR DESCRIPTION
Some node install scripts launch child node processes. Because I already have a global node installation on the path, this will invoke it with a different node installation which breaks many install scripts.

This fix should prevent that.