### PR TITLE
Fix Gradle file in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ buildscript {
     }
 }
 
+//apply kotlin2js
+apply plugin: 'kotlin2js'
 
 // apply plugin
 apply plugin: 'org.jetbrains.kotlin.frontend'
-
-// apply kotlin2js
-apply plugin: 'kotlin2js'
 
 // configure kotlin compiler
 compileKotlin2Js {


### PR DESCRIPTION
Applying frontend plugin before kotlin2js results in an error from Gradle:
```
> Failed to apply plugin [id 'org.jetbrains.kotlin.frontend']
   > Extension with name 'kotlin' does not exist. Currently registered extension names: [ext, defaultArtifacts, reporting, sourceSets, java]
```

This can be confusing for people who are looking at the sample code.