### PR TITLE
Update KotlinFrontendExtension.kt

### DIFF
--- a/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/KotlinFrontendExtension.kt
+++ b/kotlin-frontend/src/main/kotlin/org/jetbrains/kotlin/gradle/frontend/KotlinFrontendExtension.kt
@@ -76,7 +76,7 @@ open class KotlinFrontendExtension(val project: Project) : GroovyObjectSupport()
         }
     }
 
-    fun <C : BundleConfig> bundle(id: String, configure: BundleConfig.() -> Unit) {
+    fun <C : BundleConfig> bundle(id: String, configure: C.() -> Unit) {
         bundleBuilders += Pair(id, configure)
     }
 


### PR DESCRIPTION
It seems there is a typo in "bundle" method declaration.
It is declared with generic parameter "C" which is not used in method signature.
This makes impossible to configure bundles using Kotlin DSL in Gradle script